### PR TITLE
Add uv installation and LTX-Video submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LTX-Video"]
+	path = LTX-Video
+	url = https://github.com/Lightricks/LTX-Video.git

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+pip install uv 
+uv venv .venv 
+source .venv/bin/activate
+uv pip install -r requirements.txt
+uv pip install -e . --no-build-isolation


### PR DESCRIPTION
This pull request adds the necessary commands to install uv and set up the LTX-Video submodule. The uv installation commands are included in the run.sh file, and the LTX-Video submodule is added with the specified URL.